### PR TITLE
Draft - Add the ability to generate a GitHub repo with the generated framework

### DIFF
--- a/main.py
+++ b/main.py
@@ -33,6 +33,7 @@ def main(
                 or config.destination_folder,
                 "endpoint": args.endpoint,
                 "generate": GenerationOptions(args.generate),
+                "github_api_key": args.github_api_key,
             }
         )
 
@@ -48,6 +49,9 @@ def main(
         framework_generator.create_env_file(api_definitions[0])
         framework_generator.process_definitions(api_definitions, generate_tests)
         framework_generator.run_final_checks(generate_tests)
+
+        if config.github_api_key:
+            framework_generator.create_github_repo()
 
         logger.info("\n✅ Framework generation completed successfully!")
     except FileNotFoundError as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ langchain-anthropic>=0.2.4
 pydantic~=2.9.2
 dependency-injector~=4.43.0
 black~=24.2.0
+PyGithub~=1.55

--- a/src/adapters/config_adapter.py
+++ b/src/adapters/config_adapter.py
@@ -20,6 +20,7 @@ class BaseConfigAdapter(containers.DeclarativeContainer):
         config.debug = os.getenv("DEBUG", "False").title() == "True"
         config.anthropic_api_key = os.getenv("ANTHROPIC_API_KEY", "")
         config.openai_api_key = os.getenv("OPENAI_API_KEY", "")
+        config.github_api_key = os.getenv("GITHUB_API_KEY", "")
         config.destination_folder = os.getenv(
             "DESTINATION_FOLDER",
             f"./generated/generated-framework_{datetime.now().strftime('%Y%m%d-%H%M%S')}"

--- a/src/configuration/cli.py
+++ b/src/configuration/cli.py
@@ -27,4 +27,9 @@ class CLIArgumentParser:
             default="models_and_tests",
             help="Specify what to generate. 'models' for models only, 'models_and_tests' for models and tests.",
         )
+        parser.add_argument(
+            "--github-api-key",
+            type=str,
+            help="GitHub API key to create a repository (optional).",
+        )
         return parser.parse_args()

--- a/src/configuration/config.py
+++ b/src/configuration/config.py
@@ -26,6 +26,7 @@ class Config:
     api_file_path: str = ""
     destination_folder: str = ""
     endpoint: str = ""
+    github_api_key: str = ""
 
     def update(self, updates: dict[str, Any]):
         for key, value in updates.items():

--- a/src/framework_generator.py
+++ b/src/framework_generator.py
@@ -6,6 +6,7 @@ from .services.command_service import CommandService
 from .services.file_service import FileService
 from .services.llm_service import LLMService
 from .utils.logger import Logger
+from github import Github
 
 
 class FrameworkGenerator:
@@ -160,4 +161,17 @@ class FrameworkGenerator:
             self.command_service.run_linter()
         except Exception as e:
             self._log_error("Error during code quality checks", e)
+            raise
+
+    def create_github_repo(self):
+        """Create a new GitHub repository using the provided GitHub API key"""
+        try:
+            self.logger.info("\nCreating GitHub repository")
+            g = Github(self.config.github_api_key)
+            user = g.get_user()
+            repo_name = self.config.destination_folder.split('/')[-1]
+            repo = user.create_repo(repo_name)
+            self.logger.info(f"GitHub repository '{repo_name}' created successfully")
+        except Exception as e:
+            self._log_error("Error creating GitHub repository", e)
             raise


### PR DESCRIPTION
Add the ability to generate a GitHub repository with the generated framework.

* **main.py**
  - Add `github_api_key` to `config.update`.
  - Add a call to `framework_generator.create_github_repo` if `github_api_key` is provided.

* **src/adapters/config_adapter.py**
  - Add `github_api_key` to `Config` object in `get_base_config` method.

* **src/configuration/cli.py**
  - Add a new argument `--github-api-key` to the argument parser.

* **src/configuration/config.py**
  - Add `github_api_key` attribute to `Config` class.

* **src/framework_generator.py**
  - Add a new method `create_github_repo` to handle GitHub repo creation.
  - Use `github_api_key` from `config` to authenticate with GitHub API.
  - Add logic to create a new GitHub repository using the GitHub API.

* **requirements.txt**
  - Add `PyGithub` library to handle GitHub API interactions.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/damianpereira86/api-automation-agent/pull/26?shareId=25aad0b9-b922-4847-abe8-eb2e498960ba).