### PR TITLE
Generate additional tests based on initial test and models

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,13 @@ python ./main.py api-spec.yaml --endpoint /pet --generate models_and_first_test
 
 The generated framework will follow the structure:
 ```
-generated-framework_[timestamp]/
+generated-framework_[timestamp]/    # Or the Destination Folder selected 
 ├── src/
-│   ├── models/        # Generated TypeScript interfaces
-│   ├── services/      # API service classes
-│   └── tests/         # Generated test suites
+│   ├── base/                       # Framework base classes
+│   ├── models/                     # Generated TypeScript interfaces and API service classes
+│   └── tests/                      # Generated test suites
 ├── package.json
+├── (...)
 └── tsconfig.json
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,15 +58,46 @@ python ./main.py path/to/your/openapi.yaml
 - `--endpoint`: Generate framework for a specific endpoint only
 - `--generate`: Specify what to generate (default: models_and_tests)
   - `models`: Generate only the data models
-  - `models_and_tests`: Generate both data models and test suites
+  - `models_and_first_test`: Generate data models and the first test for each endpoint
+  - `models_and_tests`: Generate data models and complete test suites
 
-### Example
+### Examples
 
 ```bash
-python ./main.py api-spec.yaml --destination-folder ./my-api-client
+# Generate complete framework with all endpoints
+python ./main.py api-spec.yaml --destination-folder ./my-api-framework
 ```
 
-The generated framework will be created in your specified destination folder.
+```bash
+# Generate framework for a specific endpoint only
+python ./main.py api-spec.yaml --endpoint /user
+```
+
+```bash
+# Generate only data models for all endpoints
+python ./main.py api-spec.yaml --generate models
+```
+
+```bash
+# Generate models and first test for each endpoint in a custom folder
+python ./main.py api-spec.yaml --generate models_and_first_test --destination-folder ./quick-tests
+```
+
+```bash
+# Combine options to generate specific endpoint with first test only
+python ./main.py api-spec.yaml --endpoint /pet --generate models_and_first_test
+```
+
+The generated framework will follow the structure:
+```
+generated-framework_[timestamp]/
+├── src/
+│   ├── models/        # Generated TypeScript interfaces
+│   ├── services/      # API service classes
+│   └── tests/         # Generated test suites
+├── package.json
+└── tsconfig.json
+```
 
 ## Testing the Agent
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,31 @@ An open-source AI Agent that automatically generates an automation framework fro
     ANTHROPIC_API_KEY=your_anthropic_api_key_here
     ```
 
-## LLMs
+## Large Language Models
 
-The default model is Claude 3.5 Sonnet (claude-3-5-sonnet-20241022), which provides a good balance between performance and cost. Currently, both Anthropic (Claude) and OpenAI (GPT) models are supported. You can modify the model in the `config.py` file if needed. 
+This project supports both Anthropic and OpenAI language models:
+
+### Default Model
+**Claude 3.5 Sonnet** (claude-3-5-sonnet-20241022) is the default and recommended model
+- Provides superior code generation and understanding
+- Offers the best balance of performance and cost
+
+### Supported Models
+**Anthropic**
+  - Claude 3.5 Sonnet (claude-3-5-sonnet-20241022)
+
+**OpenAI**
+  - GPT-4o (gpt-4o)
+  - GPT-4o Mini (gpt-4o-mini)
+  - GPT-4 Turbo (gpt-4-turbo)
+  - GPT-3.5 Turbo (gpt-3.5-turbo)
+  - O1 Preview (o1-preview)
+  - O1 Mini (o1-mini)
+
+You can configure your preferred model in the `.env` file:
+```env
+MODEL=claude-3-5-sonnet-20241022  # Default value
+```
 
 ## Usage
 

--- a/api-framework-template/README.md
+++ b/api-framework-template/README.md
@@ -95,7 +95,7 @@ In case you want run it separately use the folowing scripts:
 - Check for issues:
     
     ```bash
-    npm run check
+    npm run prettier:check
     ```
     
 - Resolve issues:

--- a/api-framework-template/package.json
+++ b/api-framework-template/package.json
@@ -5,11 +5,12 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha src/**/*.spec.ts --timeout 10000",
+    "test:parallel": "mocha src/**/*.spec.ts --timeout 10000 --parallel",
     "smoke": "mocha src/**/*.spec.ts --grep @Smoke --timeout 10000",
     "regression": "mocha src/**/*.spec.ts --grep @Regression --timeout 10000",
     "lint": "npx eslint src",
     "lint:fix": "npx eslint src --fix",
-    "prettier-check": "prettier --check src",
+    "prettier:check": "prettier --check src",
     "prettify": "prettier --write src"
   },
   "author": "",

--- a/example.env
+++ b/example.env
@@ -1,5 +1,5 @@
 OPENAI_API_KEY=your_openai_api_key_here
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
-MODEL= # e.g. claude-3-5-sonnet-20241022
+MODEL=claude-3-5-sonnet-20241022 # requires Anthropic API key
 ENV=DEV # or PROD
-DEBUG=False # To enable debug mode in Langchain
+DEBUG=False # Set to True to enable debug mode in Langchain

--- a/main.py
+++ b/main.py
@@ -36,8 +36,6 @@ def main(
             }
         )
 
-        generate_tests = config.generate == GenerationOptions.MODELS_AND_TESTS
-
         logger.info(f"\nAPI file path: {config.api_file_path}")
         logger.info(f"Destination folder: {config.destination_folder}")
         logger.info(f"Endpoint: {config.endpoint}")
@@ -46,8 +44,8 @@ def main(
         api_definitions = framework_generator.process_api_definition()
         framework_generator.setup_framework()
         framework_generator.create_env_file(api_definitions[0])
-        framework_generator.process_definitions(api_definitions, generate_tests)
-        framework_generator.run_final_checks(generate_tests)
+        framework_generator.process_definitions(api_definitions, config.generate)
+        framework_generator.run_final_checks(config.generate)
 
         logger.info("\n✅ Framework generation completed successfully!")
     except FileNotFoundError as e:

--- a/main.py
+++ b/main.py
@@ -40,6 +40,7 @@ def main(
         logger.info(f"Destination folder: {config.destination_folder}")
         logger.info(f"Endpoint: {config.endpoint}")
         logger.info(f"Generate: {config.generate}")
+        logger.info(f"Model: {config.model}")
 
         api_definitions = framework_generator.process_api_definition()
         framework_generator.setup_framework()

--- a/prompts/create-additional-tests.txt
+++ b/prompts/create-additional-tests.txt
@@ -1,0 +1,378 @@
+## Role
+
+You are an expert developer specializing in TypeScript, with extensive experience in Automation Testing for REST APIs. 
+Your task is to create additional API automation test code based on an initial test and models using a custom testing framework, as detailed below.
+
+## Task
+
+- Your task is to create additional TypeScript test files for the endpoint documented on the OpenAPI Definition section.
+- Use the initial test and the models provided to generate a comprehensive set of tests for the endpoint.
+- Create tests for every status code listed in the OpenAPI definition.
+- For non-successful status codes (e.g., 400), do not use try/catch blocks. Instead, call the endpoint as you would in positive tests and assert directly against the status code. Refer to the example "@Regression - No Firstname - 400" in the Test Examples section for guidance.
+- Create tests for relevant combinations of parameters and payloads that you determine to be meaningful test cases based on best practices.
+- Use the service model class and any other models provided in the Models section as reference only; do not include them in the response. Paths in the imports must match the paths in the Models section.
+- When applicable, set up test preconditions using other endpoints in the service model class. For example, use a POST request to create a resource required for a GET test. Place these preconditions in the test itself or in before or beforeAll hooks.
+- Ensure that each call to service methods includes the appropriate response model as the generic type T. If the response type is unknown or unnecessary, pass null. There is no need to pass the Response object, just the specific response model (e.g. bookingService.getBooking<BookingModel>(bookingId);)
+- Use optional chaining (?.) when accessing properties that could potentially be undefined (e.g., response.data?.id.should.equal(orderId);) to avoid errors during runtime.
+- Create any additional models required by the tests that are not listed in the Models section.
+- Use .js extensions in all import statements.
+- You will be penalized for every TS or ESLint error.
+
+## Output
+
+The output must contain the function call for all the files generated.
+Generate all files at once.
+Make sure the output is only the function call and nothing else.
+
+## Framework Documentation
+
+### API Automation Framework (TS+Mocha)
+
+TypeScript API automation framework that does its job in a simple but effective way. It is designed to work with HTTP APIs but can be adapted to work with other protocols.
+
+Libraries used:
+
+- Mocha - Test Runner
+- Axios - HTTP client
+- Chai - Assertions
+
+This example uses the [Restful-booker](https://restful-booker.herokuapp.com/apidoc/index.html) API for demonstration purposes.
+
+#### Getting started
+
+The idea behind this framework is to encapsulate endpoints on Service Models, for maintainability and reusability. You can think of Service Models as an analogy of Page Object Models for UI Automation.
+
+#### Service Models
+
+In this framework, Service Models are used to encapsulate the API endpoints you are testing. This abstraction allows for better maintainability and reusability of your test code. The concept here is somewhat similar to the Page Object Model used in UI Automation, where each service model represents a specific set of functionality provided by your API.
+
+##### Understanding `ServiceBase`
+
+The `ServiceBase` class is the foundation of all Service Models. It provides common functionality needed for making API requests and processing responses. 
+When you create a new Service Model, it should extend `ServiceBase` to inherit these capabilities. This approach ensures consistency and reduces boilerplate code in your service models.
+
+Here's what `ServiceBase` offers:
+
+- **API Client Management**: It initializes and holds an instance of the `ApiClient`, ensuring that all service models use the same API client setup.
+- **Base URL Configuration**: It dynamically sets the base URL for API requests using the `BASEURL` from your `.env` file. This allows for flexibility across different environments (e.g., development, staging, production).
+- **Authentication**: The `authenticate` method simplifies the process of authenticating with the API. Once called, it stores the authentication token in the request headers, so subsequent API calls are authenticated. Note that as explained below in the [Authentication](#authentication) section, this is specific to this API, and must be adapted to your use case.
+- **HTTP Methods**: `ServiceBase` provides methods for common HTTP requests (GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS). These methods handle the request execution and timing, then format the response into a standardized `Response` object, making it easier to work with.
+
+##### Extending `ServiceBase`
+
+When you create a Service Model, you extend `ServiceBase` and define methods specific to the service you're testing. For example, a `BookingService` might have methods like `getBooking` or `createBooking`. Each method uses the HTTP methods provided by `ServiceBase` to interact with the API.
+
+Here's a simple example of a service model:
+
+```tsx
+import { ServiceBase } from './ServiceBase.js'; // Import the base class
+
+export class BookingService extends ServiceBase {
+  constructor() {
+    super("/booking"); // Set the endpoint path
+  }
+
+  async getBooking<T>(id: number, config = this.defaultConfig): Promise<Response<T>> {
+    return await this.get<T>(`${this.url}/${id}`, config); // Use the inherited GET method
+  }
+}
+```
+
+By extending ServiceBase, BookingService gains all the functionalities of making HTTP requests, handling authentication, and standardizing responses, allowing you to focus on the logic specific to the Booking service.
+
+##### Other Models
+
+In addition to **Service Models**, you should declare **Request** and **Response** models as needed. For example, here is the BookingModel that will be used to deserialize the response from the endpoint above.
+
+```tsx
+export interface BookingModel {
+  id?: number | undefined;
+  firstname?: string | undefined;
+  lastname?: string | undefined;
+  totalprice?: number | undefined;
+  depositpaid?: boolean | undefined;
+  bookingdates?: {
+    checkin?: string | undefined;
+    checkout?: string | undefined;
+  };
+  additionalneeds?: string | undefined;
+}
+```
+
+#### Tests
+
+Next, you can create a simple test like this. 
+
+```tsx
+describe("Get Booking", () => {
+  const bookingService = new BookingService();
+
+  it("@Smoke - Get Booking successfully - 200", async () => {
+    const bookingId = 123456;
+    const response = await bookingService.getBooking<BookingModel>(bookingId);
+    response.status.should.equal(200, JSON.stringify(response.data));
+  });
+```
+
+Note the BookingModel on the generic getBooking function that will be used to deserialize the response into a Response<BookingModel>. With that in place, you can easily assert against the response body properties.
+
+```tsx
+it("@Smoke - Get Booking successfully - 200", async () => {
+    const booking = await bookingService.addBooking<BookingResponse>({
+      firstname: "Damian",
+      lastname: "Pereira",
+      totalprice: 1000,
+      depositpaid: true,
+      bookingdates: {
+        checkin: "2024-01-01",
+        checkout: "2024-02-01",
+      },
+      additionalneeds: "Breakfast",
+    });
+
+    const bookingId = booking.data.bookingid;
+
+    const response = await bookingService.getBooking<BookingModel>(bookingId);
+    response.status.should.equal(200, JSON.stringify(response.data));
+    response.data.firstname?.should.equal(booking.data.booking.firstname);
+    response.data.lastname?.should.equal(booking.data.booking.lastname);
+    response.data.totalprice?.should.equal(booking.data.booking.totalprice);
+    response.data.depositpaid?.should.be.true;
+    response.data.bookingdates?.checkin?.should.equal(booking.data.booking.bookingdates?.checkin);
+    response.data.bookingdates?.checkout?.should.equal(booking.data.booking.bookingdates?.checkout);
+    response.data.additionalneeds?.should.equal(booking.data.booking.additionalneeds);
+  });
+```
+
+In the example above, I am using a call to the addBooking endpoint to create the booking needed for the getBooking test, and then using the newly created booking to assert against it.
+
+#### Performance
+
+Request duration is measured and saved to the responseTime property of the response object. Therefore, you can add assertions to check the response time of each request.
+
+```tsx
+it("@Regression - Get Booking successfully - Response time < 1000 ms", async () => {
+    const bookingId = 123456;
+    const response = await bookingService.getBooking<BookingModel>(bookingId);
+    response.responseTime.should.be.lessThan(1000);
+  });
+```
+
+This makes adding simple but powerful performance checks to your API automation suite very easy.
+
+#### Framework folder structure
+
+```bash
+API-FRAMEWORK
+├── .env
+├── .eslintrc.json
+├── .gitignore
+├── .mocharc.json
+├── .prettierrc.json
+└── src
+    ├── base
+		├── ApiClient.ts
+    │   └── ApiClientBase.ts
+    │   └── ServiceBase.ts
+    ├── models
+    │   ├── requests
+    │   └── responses
+		│   │  └── Response.ts
+    │   └── services
+    │     ├── AuthService.ts
+    │     └── BookingService.ts
+    └── tests
+    │   ├── auth
+    │   │   └── auth.spec.ts
+    │   └── booking
+    │       ├── AddBooking.spec.ts
+    │       ├── DeleteBooking.spec.ts
+    │       ├── GetBooking.spec.ts
+    │       ├── GetBookingIds.spec.ts
+    │       ├── PatchBooking.spec.ts
+    │       └── UpdateBooking.spec.ts
+    └── utils
+```
+
+#### File examples
+
+##### Request Model example
+
+```tsx
+export interface BookingModel {
+  id?: number | undefined;
+  firstname?: string | undefined;
+  lastname?: string | undefined;
+  totalprice?: number | undefined;
+  depositpaid?: boolean | undefined;
+  bookingdates?: {
+    checkin?: string | undefined;
+    checkout?: string | undefined;
+  };
+  additionalneeds?: string | undefined;
+}
+```
+
+##### Test examples
+
+```tsx
+import { BookingService } from "../../models/services/BookingService.js";
+import { BookingModel } from "../../models/requests/BookingModel.js";
+import chai from "chai";
+
+chai.should();
+
+describe("Add Booking", () => {
+  const bookingService = new BookingService();
+
+  it("@Smoke - Add Booking Successfully", async () => {
+    const booking: BookingModel = {
+      firstname: "Jim",
+      lastname: "Brown",
+      totalprice: 111,
+      depositpaid: true,
+      bookingdates: {
+        checkin: "2020-01-01",
+        checkout: "2021-01-01",
+      },
+      additionalneeds: "Breakfast",
+    };
+
+    const response = await bookingService.addBooking<BookingModel>(booking);
+
+    response.status.should.equal(200, JSON.stringify(response.data));
+    response.data.firstname?.should.equal(booking.firstname);
+    response.data.lastname?.should.equal(booking.lastname);
+    response.data.totalprice?.should.equal(booking.totalprice);
+    response.data.depositpaid?.should.be.true;
+    response.data.bookingdates?.checkin?.should.equal(booking.bookingdates?.checkin);
+    response.data.bookingdates?.checkout?.should.equal(booking.bookingdates?.checkout);
+    response.data.additionalneeds?.should.equal(booking.additionalneeds);
+  });
+
+  it("@Regression - Add Booking Successfully - Response time < 1000 ms", async () => {
+    const booking: BookingModel = {
+      firstname: "Jim",
+      lastname: "Brown",
+      totalprice: 111,
+      depositpaid: true,
+      bookingdates: {
+        checkin: "2020-01-01",
+        checkout: "2021-01-01",
+      },
+      additionalneeds: "Breakfast",
+    };
+
+    const response = await bookingService.addBooking<BookingResponse>(booking);
+    response.responseTime.should.be.lessThan(1000);
+  });
+
+  it("@Regression - Add Booking Successfully - Status code 201", async () => {
+    const booking: BookingModel = {
+      firstname: "Jim",
+      lastname: "Brown",
+      totalprice: 111,
+      depositpaid: true,
+      bookingdates: {
+        checkin: "2020-01-01",
+        checkout: "2021-01-01",
+      },
+      additionalneeds: "Breakfast",
+    };
+
+    const response = await bookingService.addBooking<BookingResponse>(booking);
+
+    response.status.should.equal(201);
+  });
+
+  it("@Regression - No Firstname - 400", async () => {
+    const response = await bookingService.addBooking<BookingResponse>({
+      lastname: "Snow",
+      totalprice: 1000,
+      depositpaid: true,
+      bookingdates: {
+        checkin: "2024-01-01",
+        checkout: "2024-02-01",
+      },
+      additionalneeds: "Breakfast",
+    });
+    response.status.should.equal(400);
+  });
+});
+```
+
+```tsx
+import { BookingModel } from "../../models/requests/BookingModel.js";
+import { BookingResponse } from "../../models/responses/BookingResponse.js";
+import { BookingService } from "../../models/services/BookingService.js";
+import chai from "chai";
+
+chai.should();
+
+describe("Get Booking", () => {
+  const bookingService = new BookingService();
+
+  it("@Smoke - Get Booking successfully - 200", async () => {
+    const booking = await bookingService.addBooking<BookingResponse>({
+      firstname: "Damian",
+      lastname: "Pereira",
+      totalprice: 1000,
+      depositpaid: true,
+      bookingdates: {
+        checkin: "2024-01-01",
+        checkout: "2024-02-01",
+      },
+      additionalneeds: "Breakfast",
+    });
+
+    const bookingId = booking.data.bookingid;
+
+    const response = await bookingService.getBooking<BookingModel>(bookingId);
+    response.status.should.equal(200, JSON.stringify(response.data));
+    response.data.firstname?.should.equal(booking.data.booking.firstname);
+    response.data.lastname?.should.equal(booking.data.booking.lastname);
+    response.data.totalprice?.should.equal(booking.data.booking.totalprice);
+    response.data.depositpaid?.should.be.true;
+    response.data.bookingdates?.checkin?.should.equal(booking.data.booking.bookingdates?.checkin);
+    response.data.bookingdates?.checkout?.should.equal(booking.data.booking.bookingdates?.checkout);
+    response.data.additionalneeds?.should.equal(booking.data.booking.additionalneeds);
+  });
+
+  it("@Regression - Get Booking successfully - Response time < 1000 ms", async () => {
+    const booking = await bookingService.addBooking<BookingResponse>({
+      firstname: "Damian",
+      lastname: "Pereira",
+      totalprice: 1000,
+      depositpaid: true,
+      bookingdates: {
+        checkin: "2024-01-01",
+        checkout: "2024-02-01",
+      },
+      additionalneeds: "Breakfast",
+    });
+
+    const bookingId = booking.data.bookingid;
+
+    const response = await bookingService.getBooking<BookingModel>(bookingId);
+    response.responseTime.should.be.lessThan(1000);
+  });
+
+  it("@Regression - Get Non-existent Booking - 404", async () => {
+    const bookingId = 999999999;
+    const response = await bookingService.getBooking<BookingResponse>(bookingId);
+    response.status.should.equal(404, JSON.stringify(response.data));
+  });
+});
+```
+
+## OpenAPI Definition
+
+```yaml
+{api_definition}
+```
+
+## Models
+
+```json
+{models}
+```

--- a/prompts/create-additional-tests.txt
+++ b/prompts/create-additional-tests.txt
@@ -5,13 +5,13 @@ Your task is to create additional API automation test code based on an initial t
 
 ## Task
 
-- Your task is to create additional TypeScript test files for the endpoint documented on the OpenAPI Definition section.
-- Use the initial test and the models provided to generate a comprehensive set of tests for the endpoint.
-- Create tests for every status code listed in the OpenAPI definition.
+- Your task is to create additional tests for the test file in the First Test section
+- Use the first test and the models provided to generate a comprehensive set of tests for the endpoint.
+- Create tests for every status code listed in the OpenAPI definition section.
 - For non-successful status codes (e.g., 400), do not use try/catch blocks. Instead, call the endpoint as you would in positive tests and assert directly against the status code. Refer to the example "@Regression - No Firstname - 400" in the Test Examples section for guidance.
 - Create tests for relevant combinations of parameters and payloads that you determine to be meaningful test cases based on best practices.
 - Use the service model class and any other models provided in the Models section as reference only; do not include them in the response. Paths in the imports must match the paths in the Models section.
-- When applicable, set up test preconditions using other endpoints in the service model class. For example, use a POST request to create a resource required for a GET test. Place these preconditions in the test itself or in before or beforeAll hooks.
+- When applicable, set up test preconditions using other endpoints in the service model class. For example, use a POST request to create a resource required for a GET test. If preconditions apply to several tests, place them in a before or beforeAll hook as needed.
 - Ensure that each call to service methods includes the appropriate response model as the generic type T. If the response type is unknown or unnecessary, pass null. There is no need to pass the Response object, just the specific response model (e.g. bookingService.getBooking<BookingModel>(bookingId);)
 - Use optional chaining (?.) when accessing properties that could potentially be undefined (e.g., response.data?.id.should.equal(orderId);) to avoid errors during runtime.
 - Create any additional models required by the tests that are not listed in the Models section.
@@ -24,219 +24,30 @@ The output must contain the function call for all the files generated.
 Generate all files at once.
 Make sure the output is only the function call and nothing else.
 
-## Framework Documentation
-
-### API Automation Framework (TS+Mocha)
-
-TypeScript API automation framework that does its job in a simple but effective way. It is designed to work with HTTP APIs but can be adapted to work with other protocols.
-
-Libraries used:
-
-- Mocha - Test Runner
-- Axios - HTTP client
-- Chai - Assertions
-
-This example uses the [Restful-booker](https://restful-booker.herokuapp.com/apidoc/index.html) API for demonstration purposes.
-
-#### Getting started
-
-The idea behind this framework is to encapsulate endpoints on Service Models, for maintainability and reusability. You can think of Service Models as an analogy of Page Object Models for UI Automation.
-
-#### Service Models
-
-In this framework, Service Models are used to encapsulate the API endpoints you are testing. This abstraction allows for better maintainability and reusability of your test code. The concept here is somewhat similar to the Page Object Model used in UI Automation, where each service model represents a specific set of functionality provided by your API.
-
-##### Understanding `ServiceBase`
-
-The `ServiceBase` class is the foundation of all Service Models. It provides common functionality needed for making API requests and processing responses. 
-When you create a new Service Model, it should extend `ServiceBase` to inherit these capabilities. This approach ensures consistency and reduces boilerplate code in your service models.
-
-Here's what `ServiceBase` offers:
-
-- **API Client Management**: It initializes and holds an instance of the `ApiClient`, ensuring that all service models use the same API client setup.
-- **Base URL Configuration**: It dynamically sets the base URL for API requests using the `BASEURL` from your `.env` file. This allows for flexibility across different environments (e.g., development, staging, production).
-- **Authentication**: The `authenticate` method simplifies the process of authenticating with the API. Once called, it stores the authentication token in the request headers, so subsequent API calls are authenticated. Note that as explained below in the [Authentication](#authentication) section, this is specific to this API, and must be adapted to your use case.
-- **HTTP Methods**: `ServiceBase` provides methods for common HTTP requests (GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS). These methods handle the request execution and timing, then format the response into a standardized `Response` object, making it easier to work with.
-
-##### Extending `ServiceBase`
-
-When you create a Service Model, you extend `ServiceBase` and define methods specific to the service you're testing. For example, a `BookingService` might have methods like `getBooking` or `createBooking`. Each method uses the HTTP methods provided by `ServiceBase` to interact with the API.
-
-Here's a simple example of a service model:
+## Test examples
 
 ```tsx
-import { ServiceBase } from './ServiceBase.js'; // Import the base class
-
-export class BookingService extends ServiceBase {
-  constructor() {
-    super("/booking"); // Set the endpoint path
-  }
-
-  async getBooking<T>(id: number, config = this.defaultConfig): Promise<Response<T>> {
-    return await this.get<T>(`${this.url}/${id}`, config); // Use the inherited GET method
-  }
-}
-```
-
-By extending ServiceBase, BookingService gains all the functionalities of making HTTP requests, handling authentication, and standardizing responses, allowing you to focus on the logic specific to the Booking service.
-
-##### Other Models
-
-In addition to **Service Models**, you should declare **Request** and **Response** models as needed. For example, here is the BookingModel that will be used to deserialize the response from the endpoint above.
-
-```tsx
-export interface BookingModel {
-  id?: number | undefined;
-  firstname?: string | undefined;
-  lastname?: string | undefined;
-  totalprice?: number | undefined;
-  depositpaid?: boolean | undefined;
-  bookingdates?: {
-    checkin?: string | undefined;
-    checkout?: string | undefined;
-  };
-  additionalneeds?: string | undefined;
-}
-```
-
-#### Tests
-
-Next, you can create a simple test like this. 
-
-```tsx
-describe("Get Booking", () => {
-  const bookingService = new BookingService();
-
-  it("@Smoke - Get Booking successfully - 200", async () => {
-    const bookingId = 123456;
-    const response = await bookingService.getBooking<BookingModel>(bookingId);
-    response.status.should.equal(200, JSON.stringify(response.data));
-  });
-```
-
-Note the BookingModel on the generic getBooking function that will be used to deserialize the response into a Response<BookingModel>. With that in place, you can easily assert against the response body properties.
-
-```tsx
-it("@Smoke - Get Booking successfully - 200", async () => {
-    const booking = await bookingService.addBooking<BookingResponse>({
-      firstname: "Damian",
-      lastname: "Pereira",
-      totalprice: 1000,
-      depositpaid: true,
-      bookingdates: {
-        checkin: "2024-01-01",
-        checkout: "2024-02-01",
-      },
-      additionalneeds: "Breakfast",
-    });
-
-    const bookingId = booking.data.bookingid;
-
-    const response = await bookingService.getBooking<BookingModel>(bookingId);
-    response.status.should.equal(200, JSON.stringify(response.data));
-    response.data.firstname?.should.equal(booking.data.booking.firstname);
-    response.data.lastname?.should.equal(booking.data.booking.lastname);
-    response.data.totalprice?.should.equal(booking.data.booking.totalprice);
-    response.data.depositpaid?.should.be.true;
-    response.data.bookingdates?.checkin?.should.equal(booking.data.booking.bookingdates?.checkin);
-    response.data.bookingdates?.checkout?.should.equal(booking.data.booking.bookingdates?.checkout);
-    response.data.additionalneeds?.should.equal(booking.data.booking.additionalneeds);
-  });
-```
-
-In the example above, I am using a call to the addBooking endpoint to create the booking needed for the getBooking test, and then using the newly created booking to assert against it.
-
-#### Performance
-
-Request duration is measured and saved to the responseTime property of the response object. Therefore, you can add assertions to check the response time of each request.
-
-```tsx
-it("@Regression - Get Booking successfully - Response time < 1000 ms", async () => {
-    const bookingId = 123456;
-    const response = await bookingService.getBooking<BookingModel>(bookingId);
-    response.responseTime.should.be.lessThan(1000);
-  });
-```
-
-This makes adding simple but powerful performance checks to your API automation suite very easy.
-
-#### Framework folder structure
-
-```bash
-API-FRAMEWORK
-├── .env
-├── .eslintrc.json
-├── .gitignore
-├── .mocharc.json
-├── .prettierrc.json
-└── src
-    ├── base
-		├── ApiClient.ts
-    │   └── ApiClientBase.ts
-    │   └── ServiceBase.ts
-    ├── models
-    │   ├── requests
-    │   └── responses
-		│   │  └── Response.ts
-    │   └── services
-    │     ├── AuthService.ts
-    │     └── BookingService.ts
-    └── tests
-    │   ├── auth
-    │   │   └── auth.spec.ts
-    │   └── booking
-    │       ├── AddBooking.spec.ts
-    │       ├── DeleteBooking.spec.ts
-    │       ├── GetBooking.spec.ts
-    │       ├── GetBookingIds.spec.ts
-    │       ├── PatchBooking.spec.ts
-    │       └── UpdateBooking.spec.ts
-    └── utils
-```
-
-#### File examples
-
-##### Request Model example
-
-```tsx
-export interface BookingModel {
-  id?: number | undefined;
-  firstname?: string | undefined;
-  lastname?: string | undefined;
-  totalprice?: number | undefined;
-  depositpaid?: boolean | undefined;
-  bookingdates?: {
-    checkin?: string | undefined;
-    checkout?: string | undefined;
-  };
-  additionalneeds?: string | undefined;
-}
-```
-
-##### Test examples
-
-```tsx
-import { BookingService } from "../../models/services/BookingService.js";
-import { BookingModel } from "../../models/requests/BookingModel.js";
+import {{ BookingService }} from "../../models/services/BookingService.js";
+import {{ BookingModel }} from "../../models/requests/BookingModel.js";
 import chai from "chai";
 
 chai.should();
 
-describe("Add Booking", () => {
+describe("Add Booking", () => {{
   const bookingService = new BookingService();
 
-  it("@Smoke - Add Booking Successfully", async () => {
-    const booking: BookingModel = {
+  it("@Smoke - Add Booking Successfully", async () => {{
+    const booking: BookingModel = {{
       firstname: "Jim",
       lastname: "Brown",
       totalprice: 111,
       depositpaid: true,
-      bookingdates: {
+      bookingdates: {{
         checkin: "2020-01-01",
         checkout: "2021-01-01",
-      },
+      }},
       additionalneeds: "Breakfast",
-    };
+    }};
 
     const response = await bookingService.addBooking<BookingModel>(booking);
 
@@ -248,131 +59,109 @@ describe("Add Booking", () => {
     response.data.bookingdates?.checkin?.should.equal(booking.bookingdates?.checkin);
     response.data.bookingdates?.checkout?.should.equal(booking.bookingdates?.checkout);
     response.data.additionalneeds?.should.equal(booking.additionalneeds);
-  });
+  }});
 
-  it("@Regression - Add Booking Successfully - Response time < 1000 ms", async () => {
-    const booking: BookingModel = {
+  it("@Regression - Add Booking Successfully - Response time < 1000 ms", async () => {{
+    const booking: BookingModel = {{
       firstname: "Jim",
       lastname: "Brown",
       totalprice: 111,
       depositpaid: true,
-      bookingdates: {
+      bookingdates: {{
         checkin: "2020-01-01",
         checkout: "2021-01-01",
-      },
+      }},
       additionalneeds: "Breakfast",
-    };
+    }};
 
     const response = await bookingService.addBooking<BookingResponse>(booking);
     response.responseTime.should.be.lessThan(1000);
-  });
+  }});
 
-  it("@Regression - Add Booking Successfully - Status code 201", async () => {
-    const booking: BookingModel = {
-      firstname: "Jim",
-      lastname: "Brown",
-      totalprice: 111,
-      depositpaid: true,
-      bookingdates: {
-        checkin: "2020-01-01",
-        checkout: "2021-01-01",
-      },
-      additionalneeds: "Breakfast",
-    };
-
-    const response = await bookingService.addBooking<BookingResponse>(booking);
-
-    response.status.should.equal(201);
-  });
-
-  it("@Regression - No Firstname - 400", async () => {
-    const response = await bookingService.addBooking<BookingResponse>({
+  it("@Regression - No Firstname - 400", async () => {{
+    const response = await bookingService.addBooking<BookingResponse>({{
       lastname: "Snow",
       totalprice: 1000,
       depositpaid: true,
-      bookingdates: {
+      bookingdates: {{
         checkin: "2024-01-01",
         checkout: "2024-02-01",
-      },
+      }},
       additionalneeds: "Breakfast",
-    });
+    }});
     response.status.should.equal(400);
-  });
-});
+  }});
+}});
 ```
 
 ```tsx
-import { BookingModel } from "../../models/requests/BookingModel.js";
-import { BookingResponse } from "../../models/responses/BookingResponse.js";
-import { BookingService } from "../../models/services/BookingService.js";
+import {{ BookingModel }} from "../../models/requests/BookingModel.js";
+import {{ BookingResponse }} from "../../models/responses/BookingResponse.js";
+import {{ BookingService }} from "../../models/services/BookingService.js";
 import chai from "chai";
 
 chai.should();
 
-describe("Get Booking", () => {
+describe("Get Booking", () => {{
   const bookingService = new BookingService();
+  let bookingId: number;
+  let createdBooking: Response<BookingResponse>;
 
-  it("@Smoke - Get Booking successfully - 200", async () => {
-    const booking = await bookingService.addBooking<BookingResponse>({
+  before(async () => {{
+    createdBooking = await bookingService.addBooking<BookingResponse>({{
       firstname: "Damian",
       lastname: "Pereira",
       totalprice: 1000,
       depositpaid: true,
-      bookingdates: {
+      bookingdates: {{
         checkin: "2024-01-01",
         checkout: "2024-02-01",
-      },
+      }},
       additionalneeds: "Breakfast",
-    });
+    }});
 
-    const bookingId = booking.data.bookingid;
+    bookingId = createdBooking.data.bookingid;
+  }});
 
+  it("@Smoke - Get Booking successfully - 200", async () => {{
     const response = await bookingService.getBooking<BookingModel>(bookingId);
     response.status.should.equal(200, JSON.stringify(response.data));
-    response.data.firstname?.should.equal(booking.data.booking.firstname);
-    response.data.lastname?.should.equal(booking.data.booking.lastname);
-    response.data.totalprice?.should.equal(booking.data.booking.totalprice);
+    response.data.firstname?.should.equal(createdBooking.data.booking.firstname);
+    response.data.lastname?.should.equal(createdBooking.data.booking.lastname);
+    response.data.totalprice?.should.equal(createdBooking.data.booking.totalprice);
     response.data.depositpaid?.should.be.true;
-    response.data.bookingdates?.checkin?.should.equal(booking.data.booking.bookingdates?.checkin);
-    response.data.bookingdates?.checkout?.should.equal(booking.data.booking.bookingdates?.checkout);
-    response.data.additionalneeds?.should.equal(booking.data.booking.additionalneeds);
-  });
+    response.data.bookingdates?.checkin?.should.equal(createdBooking.data.booking.bookingdates?.checkin);
+    response.data.bookingdates?.checkout?.should.equal(createdBooking.data.booking.bookingdates?.checkout);
+    response.data.additionalneeds?.should.equal(createdBooking.data.booking.additionalneeds);
+  }});
 
-  it("@Regression - Get Booking successfully - Response time < 1000 ms", async () => {
-    const booking = await bookingService.addBooking<BookingResponse>({
-      firstname: "Damian",
-      lastname: "Pereira",
-      totalprice: 1000,
-      depositpaid: true,
-      bookingdates: {
-        checkin: "2024-01-01",
-        checkout: "2024-02-01",
-      },
-      additionalneeds: "Breakfast",
-    });
-
-    const bookingId = booking.data.bookingid;
-
+  it("@Regression - Get Booking successfully - Response time < 1000 ms", async () => {{
     const response = await bookingService.getBooking<BookingModel>(bookingId);
     response.responseTime.should.be.lessThan(1000);
-  });
+  }});
 
-  it("@Regression - Get Non-existent Booking - 404", async () => {
+  it("@Regression - Get Non-existent Booking - 404", async () => {{
     const bookingId = 999999999;
     const response = await bookingService.getBooking<BookingResponse>(bookingId);
     response.status.should.equal(404, JSON.stringify(response.data));
-  });
-});
+  }});
+}});
 ```
 
-## OpenAPI Definition
+## First Test
 
-```yaml
-{api_definition}
+```json
+{tests}
 ```
 
 ## Models
 
 ```json
 {models}
+```
+
+## OpenAPI Definition
+
+```yaml
+{api_definition}
 ```

--- a/prompts/create-first-test.txt
+++ b/prompts/create-first-test.txt
@@ -269,24 +269,6 @@ describe("Add Booking", () => {{
     response.responseTime.should.be.lessThan(1000);
   }});
 
-  it("@Regression - Add Booking Successfully - Status code 201", async () => {{
-    const booking: BookingModel = {{
-      firstname: "Jim",
-      lastname: "Brown",
-      totalprice: 111,
-      depositpaid: true,
-      bookingdates: {{
-        checkin: "2020-01-01",
-        checkout: "2021-01-01",
-      }},
-      additionalneeds: "Breakfast",
-    }};
-
-    const response = await bookingService.addBooking<BookingResponse>(booking);
-
-    response.status.should.equal(201);
-  }});
-
   it("@Regression - No Firstname - 400", async () => {{
     const response = await bookingService.addBooking<BookingResponse>({{
       lastname: "Snow",
@@ -313,9 +295,11 @@ chai.should();
 
 describe("Get Booking", () => {{
   const bookingService = new BookingService();
+  let bookingId: number;
+  let createdBooking: Response<BookingResponse>;
 
-  it("@Smoke - Get Booking successfully - 200", async () => {{
-    const booking = await bookingService.addBooking<BookingResponse>({{
+  before(async () => {{
+    createdBooking = await bookingService.addBooking<BookingResponse>({{
       firstname: "Damian",
       lastname: "Pereira",
       totalprice: 1000,
@@ -327,34 +311,22 @@ describe("Get Booking", () => {{
       additionalneeds: "Breakfast",
     }});
 
-    const bookingId = booking.data.bookingid;
+    bookingId = createdBooking.data.bookingid;
+  }});
 
+  it("@Smoke - Get Booking successfully - 200", async () => {{
     const response = await bookingService.getBooking<BookingModel>(bookingId);
     response.status.should.equal(200, JSON.stringify(response.data));
-    response.data.firstname?.should.equal(booking.data.booking.firstname);
-    response.data.lastname?.should.equal(booking.data.booking.lastname);
-    response.data.totalprice?.should.equal(booking.data.booking.totalprice);
+    response.data.firstname?.should.equal(createdBooking.data.booking.firstname);
+    response.data.lastname?.should.equal(createdBooking.data.booking.lastname);
+    response.data.totalprice?.should.equal(createdBooking.data.booking.totalprice);
     response.data.depositpaid?.should.be.true;
-    response.data.bookingdates?.checkin?.should.equal(booking.data.booking.bookingdates?.checkin);
-    response.data.bookingdates?.checkout?.should.equal(booking.data.booking.bookingdates?.checkout);
-    response.data.additionalneeds?.should.equal(booking.data.booking.additionalneeds);
+    response.data.bookingdates?.checkin?.should.equal(createdBooking.data.booking.bookingdates?.checkin);
+    response.data.bookingdates?.checkout?.should.equal(createdBooking.data.booking.bookingdates?.checkout);
+    response.data.additionalneeds?.should.equal(createdBooking.data.booking.additionalneeds);
   }});
 
   it("@Regression - Get Booking successfully - Response time < 1000 ms", async () => {{
-    const booking = await bookingService.addBooking<BookingResponse>({{
-      firstname: "Damian",
-      lastname: "Pereira",
-      totalprice: 1000,
-      depositpaid: true,
-      bookingdates: {{
-        checkin: "2024-01-01",
-        checkout: "2024-02-01",
-      }},
-      additionalneeds: "Breakfast",
-    }});
-
-    const bookingId = booking.data.bookingid;
-
     const response = await bookingService.getBooking<BookingModel>(bookingId);
     response.responseTime.should.be.lessThan(1000);
   }});

--- a/src/configuration/cli.py
+++ b/src/configuration/cli.py
@@ -23,8 +23,8 @@ class CLIArgumentParser:
         parser.add_argument(
             "--generate",
             type=str,
-            choices=["models", "models_and_tests"],
+            choices=["models", "models_and_first_test", "models_and_tests"],
             default="models_and_tests",
-            help="Specify what to generate. 'models' for models only, 'models_and_tests' for models and tests.",
+            help="Specify what to generate. 'models' for models only, 'models_and_first_test' for models and first test, 'models_and_tests' for models and tests.",
         )
         return parser.parse_args()

--- a/src/configuration/config.py
+++ b/src/configuration/config.py
@@ -12,6 +12,7 @@ class Envs(Enum):
 
 class GenerationOptions(Enum):
     MODELS = "models"
+    MODELS_AND_FIRST_TEST = "models_and_first_test"
     MODELS_AND_TESTS = "models_and_tests"
 
 

--- a/src/framework_generator.py
+++ b/src/framework_generator.py
@@ -131,13 +131,13 @@ class FrameworkGenerator:
         """Generate tests for a specific verb (HTTP method) in the API definition"""
         try:
             self.logger.info(
-                f"\nGenerating tests for path: {api_definition['path']} and verb: {api_definition['verb']}"
+                f"\nGenerating first test for path: {api_definition['path']} and verb: {api_definition['verb']}"
             )
             tests = self.llm_service.generate_first_test(api_definition["yaml"], models)
             if tests:
                 self.tests_count += 1
                 self._run_code_quality_checks(tests)
-                self._generate_additional_tests(api_definition, models)
+                self._generate_additional_tests(tests, models, api_definition)
         except Exception as e:
             self._log_error(
                 f"Error processing verb definition for {api_definition['path']} - {api_definition['verb']}",
@@ -146,16 +146,20 @@ class FrameworkGenerator:
             raise
 
     def _generate_additional_tests(
-        self, api_definition: Dict[str, Any], models: List[Dict[str, Any]]
+        self,
+        tests: List[Dict[str, Any]],
+        models: List[Dict[str, Any]],
+        api_definition: Dict[str, Any],
     ):
         """Generate additional tests based on the initial test and models"""
         try:
             self.logger.info(
                 f"\nGenerating additional tests for path: {api_definition['path']} and verb: {api_definition['verb']}"
             )
-            additional_tests = self.llm_service.generate_additional_tests(api_definition["yaml"], models)
+            additional_tests = self.llm_service.generate_additional_tests(
+                tests, models, api_definition["yaml"]
+            )
             if additional_tests:
-                self.tests_count += len(additional_tests)
                 self._run_code_quality_checks(additional_tests)
         except Exception as e:
             self._log_error(

--- a/src/framework_generator.py
+++ b/src/framework_generator.py
@@ -137,9 +137,29 @@ class FrameworkGenerator:
             if tests:
                 self.tests_count += 1
                 self._run_code_quality_checks(tests)
+                self._generate_additional_tests(api_definition, models)
         except Exception as e:
             self._log_error(
                 f"Error processing verb definition for {api_definition['path']} - {api_definition['verb']}",
+                e,
+            )
+            raise
+
+    def _generate_additional_tests(
+        self, api_definition: Dict[str, Any], models: List[Dict[str, Any]]
+    ):
+        """Generate additional tests based on the initial test and models"""
+        try:
+            self.logger.info(
+                f"\nGenerating additional tests for path: {api_definition['path']} and verb: {api_definition['verb']}"
+            )
+            additional_tests = self.llm_service.generate_additional_tests(api_definition["yaml"], models)
+            if additional_tests:
+                self.tests_count += len(additional_tests)
+                self._run_code_quality_checks(additional_tests)
+        except Exception as e:
+            self._log_error(
+                f"Error generating additional tests for {api_definition['path']} - {api_definition['verb']}",
                 e,
             )
             raise

--- a/src/framework_generator.py
+++ b/src/framework_generator.py
@@ -1,6 +1,6 @@
 from typing import Optional, List, Dict, Any
 
-from .configuration.config import Config
+from .configuration.config import Config, GenerationOptions
 from .processors.swagger_processor import SwaggerProcessor
 from .services.command_service import CommandService
 from .services.file_service import FileService
@@ -67,7 +67,7 @@ class FrameworkGenerator:
     def process_definitions(
         self,
         merged_api_definition_list: List[Dict[str, Any]],
-        generate_tests: bool = True,
+        generate_tests: GenerationOptions,
     ):
         """Process the API definitions and generate models and tests"""
         try:
@@ -80,8 +80,13 @@ class FrameworkGenerator:
 
                 if api_definition["type"] == "path":
                     models = self._process_path_definition(api_definition)
-                elif generate_tests and api_definition["type"] == "verb":
-                    self._process_verb_definition(api_definition, models)
+                elif api_definition["type"] == "verb" and generate_tests in (
+                    GenerationOptions.MODELS_AND_FIRST_TEST,
+                    GenerationOptions.MODELS_AND_TESTS,
+                ):
+                    self._process_verb_definition(
+                        api_definition, models, generate_tests
+                    )
 
             self.logger.info(
                 f"\nGeneration complete. {self.models_count} models and {self.tests_count} tests were generated."
@@ -90,13 +95,16 @@ class FrameworkGenerator:
             self._log_error("Error processing definitions", e)
             raise
 
-    def run_final_checks(self, generate_tests: bool = True):
+    def run_final_checks(self, generate_tests: GenerationOptions):
         """Run final checks like TypeScript compilation and tests"""
         try:
             result = self.command_service.run_typescript_compiler()
             success, _ = result
 
-            if success and generate_tests:
+            if success and generate_tests in (
+                GenerationOptions.MODELS_AND_FIRST_TEST,
+                GenerationOptions.MODELS_AND_TESTS,
+            ):
                 self.command_service.run_tests()
 
             self.logger.info("Final checks completed")
@@ -126,7 +134,10 @@ class FrameworkGenerator:
             raise
 
     def _process_verb_definition(
-        self, api_definition: Dict[str, Any], models: List[Dict[str, Any]]
+        self,
+        api_definition: Dict[str, Any],
+        models: List[Dict[str, Any]],
+        generate_tests: GenerationOptions,
     ):
         """Generate tests for a specific verb (HTTP method) in the API definition"""
         try:
@@ -137,7 +148,8 @@ class FrameworkGenerator:
             if tests:
                 self.tests_count += 1
                 self._run_code_quality_checks(tests)
-                self._generate_additional_tests(tests, models, api_definition)
+                if generate_tests == GenerationOptions.MODELS_AND_TESTS:
+                    self._generate_additional_tests(tests, models, api_definition)
         except Exception as e:
             self._log_error(
                 f"Error processing verb definition for {api_definition['path']} - {api_definition['verb']}",

--- a/src/services/llm_service.py
+++ b/src/services/llm_service.py
@@ -60,6 +60,7 @@ class LLMService:
                     model_name=self.config.model.value,
                     temperature=1,
                     api_key=self.config.anthropic_api_key,
+                    max_tokens=8192,
                 )
             return ChatOpenAI(
                 model_name=self.config.model.value,
@@ -148,7 +149,7 @@ class LLMService:
     def generate_first_test(
         self, api_definition: Dict[str, Any], models: List[Dict[str, Any]]
     ) -> List[Dict[str, Any]]:
-        """Generate first test for API."""
+        """Generate first test from API definition and models."""
         return json.loads(
             self.create_ai_chain(PromptConfig.FIRST_TEST).invoke(
                 {"api_definition": api_definition, "models": models}
@@ -156,12 +157,15 @@ class LLMService:
         )
 
     def generate_additional_tests(
-        self, api_definition: Dict[str, Any], models: List[Dict[str, Any]]
+        self,
+        tests: List[Dict[str, Any]],
+        models: List[Dict[str, Any]],
+        api_definition: Dict[str, Any],
     ) -> List[Dict[str, Any]]:
-        """Generate additional tests for API."""
+        """Generate additional tests from tests, models and an API definition."""
         return json.loads(
             self.create_ai_chain(PromptConfig.ADDITIONAL_TESTS).invoke(
-                {"api_definition": api_definition, "models": models}
+                {"tests": tests, "models": models, "api_definition": api_definition}
             )
         )
 

--- a/src/services/llm_service.py
+++ b/src/services/llm_service.py
@@ -22,6 +22,7 @@ class PromptConfig:
     FIRST_TEST = "./prompts/create-first-test.txt"
     TESTS = "./prompts/create-tests.txt"
     FIX_TYPESCRIPT = "./prompts/fix-typescript.txt"
+    ADDITIONAL_TESTS = "./prompts/create-additional-tests.txt"
 
 
 class LLMService:
@@ -150,6 +151,16 @@ class LLMService:
         """Generate first test for API."""
         return json.loads(
             self.create_ai_chain(PromptConfig.FIRST_TEST).invoke(
+                {"api_definition": api_definition, "models": models}
+            )
+        )
+
+    def generate_additional_tests(
+        self, api_definition: Dict[str, Any], models: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        """Generate additional tests for API."""
+        return json.loads(
+            self.create_ai_chain(PromptConfig.ADDITIONAL_TESTS).invoke(
                 {"api_definition": api_definition, "models": models}
             )
         )


### PR DESCRIPTION
Add functionality to generate additional tests based on the initial test and models.

* **`src/framework_generator.py`**
  - Add `_generate_additional_tests` method to generate additional tests.
  - Call `_generate_additional_tests` in `_process_verb_definition` after generating the first test.

* **`prompts/create-additional-tests.txt`**
  - Create a new prompt file for generating additional tests based on the initial test and models.

* **`src/services/llm_service.py`**
  - Add `ADDITIONAL_TESTS` prompt configuration.
  - Add `generate_additional_tests` method to generate additional tests using the new prompt.

