### PR TITLE
Added support for an extra optional argument on FileCreationTool._parse_input()

### DIFF
--- a/src/ai_tools/file_creation_tool.py
+++ b/src/ai_tools/file_creation_tool.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import List, Type, Dict, Any
+from typing import List, Optional, Type, Dict, Any
 
 from langchain_core.tools import BaseTool
 from pydantic import BaseModel
@@ -30,8 +30,7 @@ class FileCreationTool(BaseTool):
     def _run(self, files: List[FileSpec]) -> str:
         try:
             created_files = self.file_service.create_files(
-                destination_folder=self.config.destination_folder,
-                files=files
+                destination_folder=self.config.destination_folder, files=files
             )
             self.logger.info(f"Successfully created {len(created_files)} files")
             return json.dumps([file_spec.model_dump() for file_spec in files])
@@ -42,7 +41,10 @@ class FileCreationTool(BaseTool):
     async def _arun(self, files: List[FileSpec]) -> str:
         return self._run(files)
 
-    def _parse_input(self, tool_input: str | Dict) -> Dict[str, Any]:
+    def _parse_input(
+        self, tool_input: str | Dict, tool_call_id: Optional[str] = None
+    ) -> Dict[str, Any]:
+
         if isinstance(tool_input, str):
             data = json.loads(tool_input)
         else:


### PR DESCRIPTION
An extra parameter is added to the ._parse_input method, which eliminates the error described on issue #44 

This way ._parse_input defined in file_creation_tool.py accepts 2 arguments, as ._parse_input defined in base.py, which could be causing the AI models some confusion.