### PR TITLE
Add default save_state() when none is provided in parent class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ target/
 /.idea
 
 # Framework results
+checkpoints
 /generated/*
 /logs/*
 checkpoints.db

--- a/src/utils/checkpoint.py
+++ b/src/utils/checkpoint.py
@@ -16,6 +16,23 @@ class Checkpoint:
         self.namespace = namespace or "default"
         self.logger = Logger.get_logger(__name__)
 
+        if self.obj and not hasattr(self.obj, "save_state"):
+            self._setup_default_save_state()
+
+    def _default_save_state(self):
+        """
+        Save obj and function vars as default save behavior
+        Declaring save_state() on the parent will override this default
+        """
+        self.save()
+
+    def _setup_default_save_state(self):
+        """
+        Dynamically add a default save_state function to the object instantiating Checkpoint
+        Needed for saving state when exceptions arise
+        """
+        setattr(self.obj, "save_state", self._default_save_state)
+
     def _get_checkpoint_key(self, tag=None):
         """Consistently generate the same key for the given object or tag."""
         return f"{self.namespace}_{tag or self.tag}"

--- a/src/utils/checkpoint.py
+++ b/src/utils/checkpoint.py
@@ -21,10 +21,9 @@ class Checkpoint:
 
     def _default_save_state(self):
         """
-        Save obj and function vars as default save behavior
-        Declaring save_state() on the parent will override this default
+        Declaring save_state() on the parent will override this default pass
         """
-        self.save()
+        pass
 
     def _setup_default_save_state(self):
         """


### PR DESCRIPTION
- Checkpoint now dynamically adds a save_state() method to classes that instantiate it. Avoids runtime errors if we forget to declare the save_state() func when using checkpoints.
- Default save_state() behavior is a silent function.
- Default behavior can be overriden if save_state() is declared in the parent class.