### PR TITLE
Add generation metrics display after framework completion

### DIFF
--- a/main.py
+++ b/main.py
@@ -141,7 +141,7 @@ def main(
             logger.info(f"   Duration: {format_duration(duration_seconds)}")
             logger.info(f"   Input Tokens: {usage_metadata.total_input_tokens:,}")
             logger.info(f"   Output Tokens: {usage_metadata.total_output_tokens:,}")
-            logger.info(f"   Total Cost ($): ${usage_metadata.total_cost:.4f}")
+            logger.info(f"   Total Cost (USD): ${usage_metadata.total_cost:.4f}")
 
             if test_files:
                 test_controller.run_tests_flow(test_files)


### PR DESCRIPTION
Added comprehensive metrics display after successful framework generation to provide users with valuable insights about the generation process.

## 🎯 Example Output

<img width="491" height="183" alt="image" src="https://github.com/user-attachments/assets/700b272a-8f3e-45bc-9beb-23ad75fd4c64" />

