### PR TITLE
Add support for gemini-3-flash-preview model

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ This project supports Anthropic, OpenAI, Google Generative AI, and AWS Bedrock l
 
 **Google**
 
+- Gemini 3 Flash Preview (gemini-3-flash-preview) - **Recommended: Fast + low cost**
 - Gemini 3 Pro Preview (gemini-3-pro-preview)
 
 **AWS Bedrock**
@@ -108,7 +109,7 @@ AWS Bedrock provides access to multiple model families through a unified API. Us
 
 - Claude models: anthropic.claude-sonnet-4-5-20250929-v1:0, anthropic.claude-haiku-4-5-20251001-v1:0, anthropic.claude-opus-4-5-20251101-v1:0, anthropic.claude-sonnet-4-20250514-v1:0
 - OpenAI models: openai.gpt-5.2, openai.gpt-5.1, openai.gpt-5, openai.gpt-4.1, openai.gpt-5-mini
-- Google models: google.gemini-3-pro-preview
+- Google models: google.gemini-3-flash-preview, google.gemini-3-pro-preview
 
 **Authentication Options:**
 

--- a/USAGE-GUIDE.txt
+++ b/USAGE-GUIDE.txt
@@ -34,6 +34,7 @@ OpenAI Models:
 - gpt-4.1
 
 Google Models:
+- gemini-3-flash-preview (recommended - fast + low cost)
 - gemini-3-pro-preview
 
 AWS Bedrock Models:
@@ -42,7 +43,7 @@ AWS Bedrock Models:
 - anthropic.claude-opus-4-5-20251101-v1:0
 - anthropic.claude-sonnet-4-20250514-v1:0
 - openai.gpt-5.2, openai.gpt-5.1, openai.gpt-5, openai.gpt-5-mini, openai.gpt-4.1
-- google.gemini-3-pro-preview
+- google.gemini-3-flash-preview, google.gemini-3-pro-preview
 
 MANUAL SETUP (ALTERNATIVE):
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -67,7 +67,7 @@ python benchmarks/benchmark_runner.py --openapi-spec <path_to_openapi_spec> --ll
 
 *   `--openapi-spec` (Required): Path to the OpenAPI specification file (e.g., `path/to/your/api.yaml`).
 *   `--llms` (Required): A comma-separated list of LLM models to benchmark. Do not use spaces between names.
-    *   Available choices: `GPT_5_2`, `GPT_5_1`, `GPT_5`, `GPT_4_1`, `GPT_5_MINI`, `CLAUDE_SONNET_4`, `CLAUDE_SONNET_4_5`, `CLAUDE_HAIKU_4_5`, `CLAUDE_OPUS_4_5`, `GEMINI_3_PRO_PREVIEW` (these are derived from the `Model` enum in `src/configuration/models.py`).
+    *   Available choices: `GPT_5_2`, `GPT_5_1`, `GPT_5`, `GPT_4_1`, `GPT_5_MINI`, `CLAUDE_SONNET_4`, `CLAUDE_SONNET_4_5`, `CLAUDE_HAIKU_4_5`, `CLAUDE_OPUS_4_5`, `GEMINI_3_PRO_PREVIEW`, `GEMINI_3_FLASH_PREVIEW` (these are derived from the `Model` enum in `src/configuration/models.py`).
     *   Example: `GPT_5_1,CLAUDE_SONNET_4_5`
 *   `--endpoints` (Optional): Specific endpoints to target from the OpenAPI specification. If not provided, all endpoints will be targeted.
     *   Example: `/users/{id}`

--- a/evaluations/README.md
+++ b/evaluations/README.md
@@ -295,7 +295,7 @@ Our evaluations have shown:
 
 - **Claude models (Haiku 4.5, Sonnet 4.5, Opus 4.5)**: Highly resistant to all prompt injection attacks. Consistently generate clean code without injected payloads.
 - **OpenAI models (GPT-5.2, GPT-5.1, GPT-5, GPT-4.1, GPT-5 Mini)**: Vulnerable to prompt injection. Successfully inject malicious code in test scenarios, particularly environment exfiltration attacks. GPT-5.2 shows slightly improved resistance (score: 0.67) compared to other OpenAI models (score: 0.0).
-- **Google Gemini models (Gemini 3 Pro Preview)**: Vulnerable to prompt injection, though slightly less so than OpenAI models. Evaluation scores of 0.33-0.67 (out of 1.0) across the 3 prompt injection test cases indicate partial resistance but still susceptible to injecting malicious code in generated tests.
+- **Google Gemini models (Gemini 3 Pro Preview, Gemini 3 Flash Preview)**: Vulnerable to prompt injection, though slightly less so than OpenAI models. Evaluation scores of 0.33-0.67 (out of 1.0) across the 3 prompt injection test cases indicate partial resistance but still susceptible to injecting malicious code in generated tests.
 
 #### Running the Prompt Injection Evaluation
 

--- a/src/configuration/models.py
+++ b/src/configuration/models.py
@@ -36,6 +36,10 @@ class Model(Enum):
         "gemini-3-pro-preview",
         ModelCost(input_cost_per_million_tokens=2.0, output_cost_per_million_tokens=12.0),
     )
+    GEMINI_3_FLASH_PREVIEW = (
+        "gemini-3-flash-preview",
+        ModelCost(input_cost_per_million_tokens=0.5, output_cost_per_million_tokens=3.0),
+    )
     BEDROCK_CLAUDE_SONNET_4 = (
         "anthropic.claude-sonnet-4-20250514-v1:0",
         ModelCost(input_cost_per_million_tokens=3.0, output_cost_per_million_tokens=15.0),
@@ -76,6 +80,10 @@ class Model(Enum):
         "google.gemini-3-pro-preview",
         ModelCost(input_cost_per_million_tokens=2.0, output_cost_per_million_tokens=12.0),
     )
+    BEDROCK_GEMINI_3_FLASH_PREVIEW = (
+        "google.gemini-3-flash-preview",
+        ModelCost(input_cost_per_million_tokens=0.5, output_cost_per_million_tokens=3.0),
+    )
 
     def __new__(cls, value, cost: ModelCost):
         obj = object.__new__(cls)
@@ -98,6 +106,7 @@ class Model(Enum):
     def is_google(self) -> bool:
         return self in [
             Model.GEMINI_3_PRO_PREVIEW,
+            Model.GEMINI_3_FLASH_PREVIEW,
         ]
 
     def is_bedrock(self) -> bool:
@@ -112,6 +121,7 @@ class Model(Enum):
             Model.BEDROCK_GPT_5_1,
             Model.BEDROCK_GPT_5_2,
             Model.BEDROCK_GEMINI_3_PRO_PREVIEW,
+            Model.BEDROCK_GEMINI_3_FLASH_PREVIEW,
         ]
 
     def get_costs(self) -> ModelCost:

--- a/src/utils/interactive_setup.py
+++ b/src/utils/interactive_setup.py
@@ -31,8 +31,8 @@ class InteractiveSetup:
         "3": {
             "name": "Google Generative AI",
             "env_key": "GOOGLE_API_KEY",
-            "models": ["gemini-3-pro-preview"],
-            "default_model": "gemini-3-pro-preview",
+            "models": ["gemini-3-flash-preview", "gemini-3-pro-preview"],
+            "default_model": "gemini-3-flash-preview",
         },
         "4": {
             "name": "AWS Bedrock",
@@ -48,6 +48,7 @@ class InteractiveSetup:
                 "openai.gpt-5",
                 "openai.gpt-5-mini",
                 "openai.gpt-4.1",
+                "google.gemini-3-flash-preview",
                 "google.gemini-3-pro-preview",
             ],
             "default_model": "anthropic.claude-sonnet-4-5-20250929-v1:0",

--- a/tests/integration/test_interactive_setup.py
+++ b/tests/integration/test_interactive_setup.py
@@ -336,6 +336,7 @@ class TestInteractiveSetupConfiguration:
         assert bedrock_config["default_model"] in bedrock_config["models"]
         assert "anthropic.claude-sonnet-4-5-20250929-v1:0" in bedrock_config["models"]
         assert "openai.gpt-5.2" in bedrock_config["models"]
+        assert "google.gemini-3-flash-preview" in bedrock_config["models"]
 
     def test_get_executable_directory_returns_path(self):
         """Test that get_executable_directory returns a valid path."""


### PR DESCRIPTION
## Summary

Adds support for the gemini-3-flash-preview model.

## Changes

- Added GEMINI_3_FLASH_PREVIEW to the Model enum in \src/configuration/models.py\
- Added BEDROCK_GEMINI_3_FLASH_PREVIEW for AWS Bedrock support
- Updated \is_google()\ and \is_bedrock()\ methods
- Updated interactive setup in \src/utils/interactive_setup.py\
- Updated tests in \	ests/integration/test_interactive_setup.py\
- Updated documentation (README.md, USAGE-GUIDE.txt, benchmarks/README.md, evaluations/README.md)

## Model Details

- **Provider**: Google
- **Model ID**: gemini-3-flash-preview
- **Input cost**: \.50/M tokens
- **Output cost**: \.00/M tokens

## Testing

- [x] All unit tests pass
- [x] All integration tests pass
- [x] Full test suite passes (581 tests)